### PR TITLE
Improved coding's suggested links

### DIFF
--- a/content/link_utili/coding.md
+++ b/content/link_utili/coding.md
@@ -3,15 +3,22 @@ title: Coding
 ---
 
 
-  - [Time Complexities in Python](https://wiki.python.org/moin/TimeComplexity)
-  - [Lista di esercizi Leetcode consigliati (divisi per tag/difficoltà/azienda)](https://seanprashad.com/leetcode-patterns/)
-  - [Scaletta per la preparazione (by InterviewBit)](https://www.interviewbit.com/courses/programming/) (Se non vi piace InterviewBit, limitatevi a seguirne la scaletta consigliata e a svolgere gli esercizi analoghi su LeetCode)
-  - [Top 75 LeetCode Questions to Save Your Time](https://www.teamblind.com/post/New-Year-Gift---Curated-List-of-Top-75-LeetCode-Questions-to-Save-Your-Time-OaM1orEU)
-  - [Repository di SuperheroesValley con le soluzioni degli esercizi di InterviewBit e LeetCode](https://github.com/SuperheroesValley/superheroes-exercises)
-  - [Dimostrazione del teorema della tartaruga e del coniglio](/attachments/dimostrazione_hare_tortoise.pdf) by Riccardo Mori
-  - [Descrizione degli algoritmi e strutture dati usati in Competitive Programming ](https://cp-algorithms.com/index.html)
-  - [14 patterns per la risoluzione degli esercizi](https://hackernoon.com/14-patterns-to-ace-any-coding-interview-question-c5bb3357f6ed)
-  - [Tech Interview HandBook](https://github.com/yangshun/tech-interview-handbook)
+**MISC**:
+  - [Tech Interview HandBook](https://github.com/yangshun/tech-interview-handbook): consigli, materiale per studiare e link ad esercizi per prepararsi alle interview
+  - [InterviewBit Preparation](https://www.interviewbit.com/courses/programming/): buona scaletta degli argomenti per la preparazione
+
+
+**TEORIA**:
+  - [Algorithms for Competitive Programming](https://cp-algorithms.com/index.html)
   - [Coding Interview University](https://github.com/jwasham/coding-interview-university)
-  - [Grokking the coding interview](https://www.educative.io/courses/grokking-the-coding-interview)
+  - [14 Patterns to Ace Any Coding Interview Question](https://hackernoon.com/14-patterns-to-ace-any-coding-interview-question-c5bb3357f6ed)
+  - [Grokking the coding interview](https://www.educative.io/courses/grokking-the-coding-interview): a pagamento
+  - [Overview of Bit Manipulation and Rolling Hash, with excercises and solutions](https://github.com/CoffeeStraw/CP-SWE-Interviews/blob/main/Report.pdf): curata da [Antonio Strippoli](https://github.com/CoffeeStraw)
+
+
+**PRATICA**:
+  - [Superheroes Excercises](https://github.com/SuperheroesValley/superheroes-exercises): soluzioni ad alcuni esercizi di InterviewBit e Leetcode da parte di membri di SuperheroesValley
+  - [Leetcode Patterns](https://seanprashad.com/leetcode-patterns/): lista di esercizi Leetcode consigliati (divisi per tag/difficoltà/azienda)
+  - [Top 75 LeetCode Questions to Save Your Time](https://www.teamblind.com/post/New-Year-Gift---Curated-List-of-Top-75-LeetCode-Questions-to-Save-Your-Time-OaM1orEU)
   - [Leetcode solutions for Meta](https://flint-lynx-d21.notion.site/4a2872c685da44b5a377a5f939314f18?v=20a16d33403e48fc967bb939547893b1)
+  - [Time Complexities in Python](https://wiki.python.org/moin/TimeComplexity)

--- a/content/link_utili/coding.md
+++ b/content/link_utili/coding.md
@@ -14,6 +14,7 @@ title: Coding
   - [14 Patterns to Ace Any Coding Interview Question](https://hackernoon.com/14-patterns-to-ace-any-coding-interview-question-c5bb3357f6ed)
   - [Grokking the coding interview](https://www.educative.io/courses/grokking-the-coding-interview): a pagamento
   - [Overview of Bit Manipulation and Rolling Hash, with excercises and solutions](https://github.com/CoffeeStraw/CP-SWE-Interviews/blob/main/Report.pdf): curata da [Antonio Strippoli](https://github.com/CoffeeStraw)
+  - [Dimostrazione del teorema della tartaruga e del coniglio](/attachments/dimostrazione_hare_tortoise.pdf): curata da Riccardo Mori
 
 
 **PRATICA**:


### PR DESCRIPTION
Organized links, removed "Dimostrazione del teorema della tartaruga e del coniglio" by Riccardo Mori due to it being unavailable, added "overview of bit manipulation and rolling hash".

Da controllare se il link di riccardo mori è reperibile altrove. In tal caso sarebbe bello riaggiungerlo.