### PR TITLE
fix: change SuperHeroes references to SuperHero 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# SuperHeroWiki
+# Superhero Wiki
 
-Questa è la repo della Wiki di SuperHeroValley. La wiki è raggiungibile dal seguente link: [https://wiki.superherovalley.fun/](https://wiki.superherovalley.fun/).
+Questa è la repo della Wiki di Superhero Valley. La wiki è raggiungibile dal seguente link: [https://wiki.superherovalley.fun/](https://wiki.superherovalley.fun/).
 
-Per maggiori informazioni riguardo a SuperHeroValley potete fare riferimento al [nostro sito web](https://wiki.superherovalley.fun/).
+Per maggiori informazioni riguardo a Superhero Valley potete fare riferimento al [nostro sito web](https://wiki.superherovalley.fun/).
 
 ## Obiettivo della wiki
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# SuperHeroesWiki
+# SuperHeroWiki
 
-Questa è la repo della Wiki di SuperHeroesValley. La wiki è raggiungibile dal seguente link: [https://wiki.superheroesvalley.fun/](https://wiki.superheroesvalley.fun/).
+Questa è la repo della Wiki di SuperHeroValley. La wiki è raggiungibile dal seguente link: [https://wiki.superherovalley.fun/](https://wiki.superherovalley.fun/).
 
-Per maggiori informazioni riguardo a SuperHeroesValley potete fare riferimento al [nostro sito web](https://www.superheroesvalley.fun/).
+Per maggiori informazioni riguardo a SuperHeroValley potete fare riferimento al [nostro sito web](https://wiki.superherovalley.fun/).
 
 ## Obiettivo della wiki
 

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 baseURL = "http://localhost"
-title = "SuperHeroesWiki"
+title = "SuperHeroWiki"
 theme = "hugo-geekdoc"
 
 pluralizeListTitles = false

--- a/content/_index.md
+++ b/content/_index.md
@@ -4,11 +4,11 @@ weight: -20
 
 ---
 
-# Cos’è SuperHero Valley:
+# Cos’è Superhero Valley:
 
-SuperHero Valley è una community nata nell’Ottobre 2020 con l’obiettivo di instaurare un ponte tra l’università e le grandi aziende nel campo dell’informatica. 
+Superhero Valley è una community nata nell’Ottobre 2020 con l’obiettivo di instaurare un ponte tra l’università e le grandi aziende nel campo dell’informatica. 
 In altre nazioni è comune, durante il periodo universitario, seguire corsi tarati per sostenere tech interviews e svolgere internships in grandi aziende. Queste attività sono pressoché inesistenti e sconosciute in Italia.
-Ottenere un’offerta di internship, o anche una posizione Full Time, dalle aziende della Silicon Valley non è impresa facile senza la dovuta preparazione. Queste richiedono competenze precise e comportamenti da seguire, che SuperHero Valley punta ad insegnare agli studenti attraverso appuntamenti a cadenza settimanale:
+Ottenere un’offerta di internship, o anche una posizione Full Time, dalle aziende della Silicon Valley non è impresa facile senza la dovuta preparazione. Queste richiedono competenze precise e comportamenti da seguire, che Superhero Valley punta ad insegnare agli studenti attraverso appuntamenti a cadenza settimanale:
 
 - Talk di persone che lavorano in grandi aziende con argomento la loro storia e indicazioni utili per affrontare una tech interview.
 - Simulazioni di Tech Interviews (chiamate Mock interview) svolte da persone che lavorano in grandi aziende, con l’obiettivo di quantificare il grado di preparazione dello studente. A discrezione dell’interviewer, è anche possibile premiare i candidati promettenti con un referral che permette di saltare la fase di “cv screening”.

--- a/content/_index.md
+++ b/content/_index.md
@@ -4,11 +4,11 @@ weight: -20
 
 ---
 
-# Cos’è SuperHeroes Valley:
+# Cos’è SuperHero Valley:
 
-SuperHeroes Valley è una community nata nell’Ottobre 2020 con l’obiettivo di instaurare un ponte tra l’università e le grandi aziende nel campo dell’informatica. 
+SuperHero Valley è una community nata nell’Ottobre 2020 con l’obiettivo di instaurare un ponte tra l’università e le grandi aziende nel campo dell’informatica. 
 In altre nazioni è comune, durante il periodo universitario, seguire corsi tarati per sostenere tech interviews e svolgere internships in grandi aziende. Queste attività sono pressoché inesistenti e sconosciute in Italia.
-Ottenere un’offerta di internship, o anche una posizione Full Time, dalle aziende della Silicon Valley non è impresa facile senza la dovuta preparazione. Queste richiedono competenze precise e comportamenti da seguire, che SuperHeroes Valley punta ad insegnare agli studenti attraverso appuntamenti a cadenza settimanale:
+Ottenere un’offerta di internship, o anche una posizione Full Time, dalle aziende della Silicon Valley non è impresa facile senza la dovuta preparazione. Queste richiedono competenze precise e comportamenti da seguire, che SuperHero Valley punta ad insegnare agli studenti attraverso appuntamenti a cadenza settimanale:
 
 - Talk di persone che lavorano in grandi aziende con argomento la loro storia e indicazioni utili per affrontare una tech interview.
 - Simulazioni di Tech Interviews (chiamate Mock interview) svolte da persone che lavorano in grandi aziende, con l’obiettivo di quantificare il grado di preparazione dello studente. A discrezione dell’interviewer, è anche possibile premiare i candidati promettenti con un referral che permette di saltare la fase di “cv screening”.

--- a/content/link_utili/coding.md
+++ b/content/link_utili/coding.md
@@ -29,5 +29,5 @@ title: Coding
  - [Overview of Bit Manipulation and Rolling Hash, with excercises and solutions](https://github.com/CoffeeStraw/CP-SWE-Interviews/blob/main/Report.pdf): curata da [Antonio Strippoli](https://github.com/CoffeeStraw)
  - [Algorithms for coding interviews](/attachments/Algorithms-for-coding-interviews.pdf): by [Stefano Ivancich](https://github.com/ivaste)
  - [Dimostrazione del teorema della tartaruga e del coniglio](/attachments/dimostrazione_hare_tortoise.pdf): by [Riccardo Mori](https://github.com/patacca)
- - [Superheroes Excercises Repository](https://github.com/SuperheroesValley/superheroes-exercises): soluzioni ad alcuni esercizi di InterviewBit e Leetcode da parte di membri di SuperheroesValley
+ - [Superhero Excercises Repository](https://github.com/SuperheroesValley/superheroes-exercises): soluzioni ad alcuni esercizi di InterviewBit e Leetcode da parte di membri di Superhero Valley
  

--- a/content/usage/contatti.md
+++ b/content/usage/contatti.md
@@ -10,6 +10,6 @@ Per le comunicazioni più generali, come ad esempio annunci talk o sondaggi sull
 - [Gruppo Discord](https://discord.com/invite/rNZx6JpMkt):
 Per le comunicazioni più specifiche, è organizzato in canali e sono presenti anche dai canali audio in cui sono stati svolti i meeting per confrontarsi sugli esercizi.
 
-- [Sito ufficiale](https://www.superheroesvalley.fun/)
+- [Sito ufficiale](https://superherovalley.fun/)
 - [Mail](mailto:info@superheroesvalley.fun)
 

--- a/content/usage/faq.md
+++ b/content/usage/faq.md
@@ -11,23 +11,23 @@ Si, le internship in tutte le grandi aziende sono pagate. Oltre allo stipendio m
 
 ## - Come posso prepararmi alle coding interview? 
 
-Per prepararsi alle coding interview è necessario avere una conoscenza di base di algoritmi e strutture dati, [nella nostra wiki](https://wiki.superheroesvalley.fun/) trovi molte risorse per ripassare o studiare questi argomenti.
+Per prepararsi alle coding interview è necessario avere una conoscenza di base di algoritmi e strutture dati, [nella nostra wiki](https://wiki.superherovalley.fun/) trovi molte risorse per ripassare o studiare questi argomenti.
 La nostra community offre inoltre la possibilità di fare esercizi in gruppo e mock interview per prepararsi al meglio ai colloqui. 
 Se vuoi saperne di più iscriviti [al nostro server Discord](https://discord.com/invite/DsRJgkraTa).
 
 ## - Come si scrive un buon CV?
 
-[Nella nostra wiki](https://wiki.superheroesvalley.fun/features/cv/) abbiamo una sezione che raccoglie molti consigli utili per scrivere un buon curriculum.
+[Nella nostra wiki](https://wiki.superherovalley.fun/features/cv/) abbiamo una sezione che raccoglie molti consigli utili per scrivere un buon curriculum.
 [Nel nostro server Discord](https://discord.com/invite/DsRJgkraTa) vi forniamo inoltre la possibilità di inviare il vostro CV per ricevere dei consigli su come migliorarlo.
 
-## - Posso partecipare a SuperHeroes Valley anche se sono al primo anno di università? 
+## - Posso partecipare a SuperHero Valley anche se sono al primo anno di università? 
 
 Ovviamente si! Il nostro obiettivo è dare da subito maggiore consapevolezza delle possibilità che molte aziende possono offrirvi, ad esempio Google offre agli studenti del primo e secondo anno un programma di internship chiamato [STEP](https://buildyourfuture.withgoogle.com/programs/step/). 
  
 
 ## - Quando posso fare domanda per le internship? 
 
-L'apertura del periodo di candidatura varia in base all'azienda. Vi consigliamo di visionare la lista di aziende che abbiamo inserito [nella nostra wiki](https://wiki.superheroesvalley.fun/features/ricerca_internships/) e di cercare poi la pagina "Career" o "Jobs opening" dell'azienda che vi interessa.
+L'apertura del periodo di candidatura varia in base all'azienda. Vi consigliamo di visionare la lista di aziende che abbiamo inserito [nella nostra wiki](https://wiki.superherovalley.fun/features/ricerca_internships/) e di cercare poi la pagina "Career" o "Jobs opening" dell'azienda che vi interessa.
 
 ## - Per svolgere una internship è necessario spostarsi nella città dove è presente la sede dell'azienda?
 

--- a/content/usage/faq.md
+++ b/content/usage/faq.md
@@ -20,7 +20,7 @@ Se vuoi saperne di più iscriviti [al nostro server Discord](https://discord.com
 [Nella nostra wiki](https://wiki.superherovalley.fun/features/cv/) abbiamo una sezione che raccoglie molti consigli utili per scrivere un buon curriculum.
 [Nel nostro server Discord](https://discord.com/invite/DsRJgkraTa) vi forniamo inoltre la possibilità di inviare il vostro CV per ricevere dei consigli su come migliorarlo.
 
-## - Posso partecipare a SuperHero Valley anche se sono al primo anno di università? 
+## - Posso partecipare a Superhero Valley anche se sono al primo anno di università? 
 
 Ovviamente si! Il nostro obiettivo è dare da subito maggiore consapevolezza delle possibilità che molte aziende possono offrirvi, ad esempio Google offre agli studenti del primo e secondo anno un programma di internship chiamato [STEP](https://buildyourfuture.withgoogle.com/programs/step/). 
  

--- a/content/usage/manifesto.md
+++ b/content/usage/manifesto.md
@@ -4,11 +4,11 @@ weight: -20
 
 ---
 
-# Cos’è SuperHero Valley:
+# Cos’è Superhero Valley:
 
-SuperHero Valley è una community nata nell’Ottobre 2020 con l’obiettivo di instaurare un ponte tra l’università e le grandi aziende nel campo dell’informatica. 
+Superhero Valley è una community nata nell’Ottobre 2020 con l’obiettivo di instaurare un ponte tra l’università e le grandi aziende nel campo dell’informatica. 
 In altre nazioni è comune, durante il periodo universitario, seguire corsi tarati per sostenere tech interviews e svolgere internships in grandi aziende. Queste attività sono pressoché inesistenti e sconosciute in Italia.
-Ottenere un’offerta di internship, o anche una posizione Full Time, dalle aziende della Silicon Valley non è impresa facile senza la dovuta preparazione. Queste richiedono competenze precise e comportamenti da seguire, che SuperHero Valley punta ad insegnare agli studenti attraverso appuntamenti a cadenza settimanale:
+Ottenere un’offerta di internship, o anche una posizione Full Time, dalle aziende della Silicon Valley non è impresa facile senza la dovuta preparazione. Queste richiedono competenze precise e comportamenti da seguire, che Superhero Valley punta ad insegnare agli studenti attraverso appuntamenti a cadenza settimanale:
 
 - Talk di persone che lavorano in grandi aziende con argomento la loro storia e indicazioni utili per affrontare una tech interview.
 - Simulazioni di Tech Interviews (chiamate Mock interview) svolte da persone che lavorano in grandi aziende, con l’obiettivo di quantificare il grado di preparazione dello studente. A discrezione dell’interviewer, è anche possibile premiare i candidati promettenti con un referral che permette di saltare la fase di “cv screening”.

--- a/content/usage/manifesto.md
+++ b/content/usage/manifesto.md
@@ -4,11 +4,11 @@ weight: -20
 
 ---
 
-# Cos’è SuperHeroes Valley:
+# Cos’è SuperHero Valley:
 
-SuperHeroes Valley è una community nata nell’Ottobre 2020 con l’obiettivo di instaurare un ponte tra l’università e le grandi aziende nel campo dell’informatica. 
+SuperHero Valley è una community nata nell’Ottobre 2020 con l’obiettivo di instaurare un ponte tra l’università e le grandi aziende nel campo dell’informatica. 
 In altre nazioni è comune, durante il periodo universitario, seguire corsi tarati per sostenere tech interviews e svolgere internships in grandi aziende. Queste attività sono pressoché inesistenti e sconosciute in Italia.
-Ottenere un’offerta di internship, o anche una posizione Full Time, dalle aziende della Silicon Valley non è impresa facile senza la dovuta preparazione. Queste richiedono competenze precise e comportamenti da seguire, che SuperHeroes Valley punta ad insegnare agli studenti attraverso appuntamenti a cadenza settimanale:
+Ottenere un’offerta di internship, o anche una posizione Full Time, dalle aziende della Silicon Valley non è impresa facile senza la dovuta preparazione. Queste richiedono competenze precise e comportamenti da seguire, che SuperHero Valley punta ad insegnare agli studenti attraverso appuntamenti a cadenza settimanale:
 
 - Talk di persone che lavorano in grandi aziende con argomento la loro storia e indicazioni utili per affrontare una tech interview.
 - Simulazioni di Tech Interviews (chiamate Mock interview) svolte da persone che lavorano in grandi aziende, con l’obiettivo di quantificare il grado di preparazione dello studente. A discrezione dell’interviewer, è anche possibile premiare i candidati promettenti con un referral che permette di saltare la fase di “cv screening”.

--- a/data/menu/more.yaml
+++ b/data/menu/more.yaml
@@ -1,7 +1,7 @@
 ---
 more:
   - name: Home
-    ref: "https://www.superheroesvalley.fun/"
+    ref: "https://superherovalley.fun/"
     external: true
     icon: "home"
   - name: "Contribute"


### PR DESCRIPTION
Hi!

As mentioned in the discord channel I found out that the references to the new [wiki](https://wiki.superherovalley.fun/) and the main [website](https://superherovalley.fun/) were broken because your brand SuperHeroes Valley has been changed into SuperHero Valley.

I've just refactored some links related to the old wiki, the old websites and the old brand name, just removing the "es" suffix from the old brand name.

Even if it's a small change I will be delighted contribute to this repo in order to support the amazing work that you do!  